### PR TITLE
Corrected indexed setter and getter for face indices.

### DIFF
--- a/src/lib/io/DataStruct.hpp
+++ b/src/lib/io/DataStruct.hpp
@@ -104,6 +104,9 @@ typedef boost::shared_array< coord<float> > coord3fArr;
 typedef boost::shared_array< idxVal<float> > idx1fArr;
 
 
+typedef boost::shared_array< coord<unsigned int> > idx3uArr;
+
+
 typedef boost::shared_array< idxVal<unsigned int> > idx1uArr;
 
 

--- a/src/lib/io/MeshBuffer.cpp
+++ b/src/lib/io/MeshBuffer.cpp
@@ -49,6 +49,7 @@ MeshBuffer::MeshBuffer() :
      * vice versa. */
 	assert( 3 * sizeof(float) == sizeof(coord<float>) );
 	assert( 3 * sizeof(uchar) == sizeof(color<uchar>) );
+	assert( 3 * sizeof(unsigned int) == sizeof(coord<unsigned int>) );
 	assert( sizeof(float) == sizeof(idxVal<float>) );
 
     /* Reset all internal buffer. */
@@ -174,11 +175,11 @@ color3bArr MeshBuffer::getIndexedVertexColorArray( size_t &n )
 }
 
 
-idx1uArr MeshBuffer::getIndexedFaceArray( size_t &n )
+idx3uArr MeshBuffer::getIndexedFaceArray( size_t &n )
 {
 
     n = m_numFaces;
-    idx1uArr p = *((idx1uArr*) &m_faceIndices);
+    idx3uArr p = *((idx3uArr*) &m_faceIndices);
     return p;
 
 }
@@ -352,6 +353,15 @@ void MeshBuffer::setIndexedVertexTextureCoordinateArray( coord3fArr arr, size_t 
 
     m_vertexTextureCoordinates = *((floatArr*) &arr);
     m_numVertexTextureCoordinates = size;
+
+}
+
+
+void MeshBuffer::setIndexedFaceArray( idx3uArr arr, size_t size )
+{
+
+    m_faceIndices = *((uintArr*) &arr);
+    m_numFaces    = size;
 
 }
 

--- a/src/lib/io/MeshBuffer.hpp
+++ b/src/lib/io/MeshBuffer.hpp
@@ -264,7 +264,7 @@ class MeshBuffer
         coord3fArr getIndexedVertexTextureCoordinateArray( size_t &n );
 
 
-        idx1uArr getIndexedFaceArray( size_t &n );
+        idx3uArr getIndexedFaceArray( size_t &n );
 
 
         color3bArr getIndexedFaceColorArray( size_t &n );
@@ -516,6 +516,9 @@ class MeshBuffer
         void setIndexedFaceColorArray( color3bArr arr, size_t size );
 
 
+        void setIndexedFaceArray( idx3uArr arr, size_t size );
+
+
 
 #define SECTION_INDEXED_VECTOR_SETTER
         /**********************************************************************
@@ -555,7 +558,7 @@ class MeshBuffer
 
 
 
-#define SECTION_INDEXED_SETTER
+#define SECTION_ADDITIONAL_STUFF
         /**********************************************************************
          * THE OTHERS
          *********************************************************************/


### PR DESCRIPTION
Before this the indexed setter/getter for faces was actually one for an interlaced array, too.
