### PR TITLE
Make shure m_model is set in every io read operation

### DIFF
--- a/src/lib/io/LasIO.cpp
+++ b/src/lib/io/LasIO.cpp
@@ -73,6 +73,7 @@ ModelPtr LasIO::read(string filename )
         p_buffer->setPointIntensityArray(intensities, num_points);
 
         ModelPtr m_ptr( new Model(p_buffer));
+        m_model = m_ptr;
 
         delete lasreader;
 

--- a/src/lib/io/PLYIO.cpp
+++ b/src/lib/io/PLYIO.cpp
@@ -733,6 +733,7 @@ ModelPtr PLYIO::read( string filename, bool readColor, bool readConfidence,
     }
 
     ModelPtr m( new Model( mesh, pc ) );
+    m_model = m;
     return m;
 
 }

--- a/src/lib/io/UosIO.cpp
+++ b/src/lib/io/UosIO.cpp
@@ -168,6 +168,7 @@ ModelPtr UosIO::read(string dir)
         cout << timestamp << "UOSReader: " << dir << " is not a directory." << endl;
     }
 
+    m_model = model;
     return model;
 }
 


### PR DESCRIPTION
The io classes all have an internal model (BaseIO.hpp:131:  ModelPtr m_model;) which should be set in the read methods of each specific io class. It was not. This might become a problem if you read a model, modify it and save it again.
