### PR TITLE
Got lib/display out of lib/io (GridIO)

### DIFF
--- a/src/lib/io/GridIO.cpp
+++ b/src/lib/io/GridIO.cpp
@@ -37,43 +37,54 @@ GridIO::GridIO()
 
 }
 
-Grid* GridIO::read(string filename)
+void GridIO::read( std::string filename )
 {
     ifstream in(filename.c_str());
 
     if(in.good())
     {
-        int n_points;
-        int n_cells;
+        size_t n_points;
+        size_t n_cells;
         float voxelsize;
 
         // Read header
         in >> n_points >> voxelsize >> n_cells;
 
         // Alloc and read points
-        floatArr points(new float[4 * n_points]);
-        for(int i = 0; i < n_points; i++)
+        m_points = floatArr( new float[4 * n_points] );
+        m_numPoints = n_points;
+        for(size_t i = 0; i < n_points; i++)
         {
-            in >> points[i * 4] >> points[i * 4 + 1] >> points[i * 4 + 2] >> points[i * 4 + 3];
+            in >> m_points[i * 4] >> m_points[i * 4 + 1] >> m_points[i * 4 + 2] >> m_points[i * 4 + 3];
         }
 
         // Alloc and read box indices
-        uintArr boxes(new uint[8 * n_cells]);
-        for(int i = 0; i < n_cells; i++)
+        m_boxes = uintArr( new uint[8 * n_cells] );
+        m_numBoxes = n_cells;
+        for(size_t i = 0; i < n_cells; i++)
         {
-            int pos = i * 8;
-            for(int j = 0; j < 8; j++)
+            size_t pos = i * 8;
+            for(size_t j = 0; j < 8; j++)
             {
-                in >> boxes[pos + j];
+                in >> m_boxes[pos + j];
             }
         }
 
-        return new Grid(points, boxes, n_points, n_cells);
     }
-    else
-    {
-        return 0;
-    }
+}
+
+
+floatArr GridIO::getPoints( size_t &n )
+{
+    n = m_numPoints;
+    return m_points;
+}
+
+
+uintArr GridIO::getBoxes( size_t &n )
+{
+    n = m_numBoxes;
+    return m_boxes;
 }
 
 

--- a/src/lib/io/GridIO.hpp
+++ b/src/lib/io/GridIO.hpp
@@ -26,7 +26,7 @@
 #ifndef GRIDIO_HPP_
 #define GRIDIO_HPP_
 
-#include "display/Grid.hpp"
+#include "DataStruct.hpp"
 
 namespace lssr
 {
@@ -35,8 +35,17 @@ class GridIO
 {
 public:
     GridIO();
-    Grid* read(string filename);
+    void read( std::string filename );
     virtual ~GridIO();
+
+    floatArr getPoints( size_t &n );
+    uintArr  getBoxes(  size_t &n );
+
+private:
+    floatArr m_points;
+    uintArr  m_boxes;
+    size_t   m_numPoints;
+    size_t   m_numBoxes;
 };
 
 } /* namespace lssr */

--- a/src/qglviewer/data/DataCollectorFactory.cpp
+++ b/src/qglviewer/data/DataCollectorFactory.cpp
@@ -153,9 +153,13 @@ void DataCollectorFactory::create(string filename)
 	    if(extension == ".grid")
 	    {
 	        GridIO io;
-	        Grid* grid = io.read(filename);
-	        if(grid)
+	        io.read( filename );
+            size_t n_points, n_boxes;
+            floatArr points = io->getPoints( n_points );
+            uintArr  boxes  = io->getBoxes(  n_boxes );
+	        if( points && boxes )
 	        {
+                Grid* grid = new Grid( points, boxes, n_points, n_cells );
 	            int modes = 0;
 	            PointCloudTreeWidgetItem* item = new PointCloudTreeWidgetItem(PointCloudItem);
 	            item->setSupportedRenderModes(modes);


### PR DESCRIPTION
This is a proposal for a slight modification of the GridIO interface. In the old days the io-lib was more or less independent for the display-lib (more more than less) but GridIO used the Grid class from display.  With this slight modification it is seperated ance again, as the Grid object is instanciated outside of GridIO. Have a look at it, keep it or throw it away.
