### PR TITLE
Workaround for bug(?) in old gcc versions.

### DIFF
--- a/src/lib/io/ModelFactory.hpp
+++ b/src/lib/io/ModelFactory.hpp
@@ -46,13 +46,15 @@ namespace lssr
  */
 class ModelFactory
 {
+    typedef std::multimap< std::string, std::string >  optionMap;
+
     public:
 
         static ModelPtr readModel( std::string filename );
 
         static void saveModel( ModelPtr m, std::string file,
-                std::multimap< std::string, std::string > options 
-                = std::multimap< std::string, std::string >() );
+                std::multimap< std::string, std::string > options
+                = optionMap() );
 
 };
 


### PR DESCRIPTION
Fix for Redmine Issue  #97
Tested with:
- gcc version 4.1.2 20080704 (Red Hat 4.1.2-51) on a CentOS 5 system
- gcc version 4.6.2 20111027 (Red Hat 4.6.2-1) (GCC) on a Fedora 16 system
