### PR TITLE
Fix compiler error in include/lvr/io/STLIO.hpp

### DIFF
--- a/include/lvr/io/STLIO.hpp
+++ b/include/lvr/io/STLIO.hpp
@@ -22,7 +22,6 @@ public:
 	STLIO();
 	virtual ~STLIO();
 
-	virtual ModelPtr read(string filename);
 	virtual void save( string filename );
 	virtual void save( ModelPtr model, string filename );
     /**


### PR DESCRIPTION
Remove double declaration of “virtual ModelPtr read(string filename );” (credits to @LukasKalbertodt)